### PR TITLE
Add editing and drag-and-drop ordering for Pós-vendas cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,42 @@
         </div>
       </form>
     </dialog>
+
+    <!-- Modal editar Pós-vendas -->
+    <dialog id="posCardDialog" class="dialog">
+      <form method="dialog" id="posCardForm" class="card">
+        <h3>Editar card Pós-vendas</h3>
+        <input type="hidden" id="posCardId">
+        <label>Seção
+          <select id="posCardSection" required>
+            <option value="top">Fluxo principal</option>
+            <option value="bottom">Opções de resolução</option>
+          </select>
+        </label>
+        <label>Visual
+          <select id="posCardVariant" required>
+            <option value="case">Caso</option>
+            <option value="option">Opção</option>
+          </select>
+        </label>
+        <label>Título
+          <input type="text" id="posCardTitle" required>
+        </label>
+        <label>Parágrafos (um por linha)
+          <textarea id="posCardParagraphs" rows="6" placeholder="Digite cada parágrafo em uma nova linha"></textarea>
+        </label>
+        <label>Lista com marcadores (um item por linha)
+          <textarea id="posCardBullets" rows="6" placeholder="Digite cada item em uma nova linha"></textarea>
+        </label>
+        <label>Nota final
+          <textarea id="posCardNote" rows="3" placeholder="Observação opcional"></textarea>
+        </label>
+        <div class="row right gap">
+          <button class="btn btn-ghost" value="cancel">Cancelar</button>
+          <button class="btn" value="default" type="submit">Salvar card</button>
+        </div>
+      </form>
+    </dialog>
   </main>
 
   <footer class="footer muted small">

--- a/styles.css
+++ b/styles.css
@@ -151,6 +151,8 @@ input::placeholder, textarea::placeholder { color: #94a3b8; }
   gap: 0;
   box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.4);
 }
+.qa[draggable="true"], .pos-card[draggable="true"] { cursor: grab; }
+.qa.dragging, .pos-card.dragging { opacity: 0.65; }
 .qa-head {
   padding: 20px 22px 16px;
   display:flex;
@@ -298,6 +300,8 @@ input::placeholder, textarea::placeholder { color: #94a3b8; }
   display:flex;
   align-items:center;
   gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .pos-card__actions .btn {


### PR DESCRIPTION
## Summary
- add Firestore-backed management for Pós-vendas / Quebras cards with edit and delete controls
- support drag-and-drop reordering of FAQ and Pós-vendas cards, persisting order in Firestore
- seed default Pós-vendas content and update styling/modal assets for the new workflow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dc12c4c1d0832abda34710fdc25527