### PR TITLE
Ensure copy buttons only copy response content

### DIFF
--- a/app.js
+++ b/app.js
@@ -469,10 +469,8 @@ function createPosCard(card) {
   body.appendChild(feedback);
 
   const copyLines = [
-    chip.textContent,
-    card.title,
     ...(card.paragraphs || []),
-    ...(card.bullets || []),
+    ...((card.bullets || []).map(item => `• ${item}`)),
     card.note || null
   ].filter(Boolean);
 


### PR DESCRIPTION
## Summary
- update pós-vendas copy button to copy only the response body
- keep bullet items formatted with leading bullets while excluding metadata

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e553bcef30832ab1f09d63a9bb1d06