### PR TITLE
Refine system menu layout and dynamic category colors

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,7 +104,7 @@ const STATIC_CATEGORY_LAYOUT = [
   { key: 'extra', categories: ['PRODUTOS E MEDIDAS', ALL_TAB_LABEL, SUMMARY_TAB_LABEL] }
 ];
 
-const ORANGE_TAB_STYLE = {
+const SHOPEE_TAB_STYLE = {
   bg: '#f97316',
   color: '#7c2d12',
   chipBg: '#ffedd5',
@@ -112,7 +112,7 @@ const ORANGE_TAB_STYLE = {
   shadow: '0 18px 34px -20px rgba(249, 115, 22, 0.55)'
 };
 
-const GOLD_TAB_STYLE = {
+const ML_TAB_STYLE = {
   bg: '#facc15',
   color: '#713f12',
   chipBg: '#fef9c3',
@@ -121,13 +121,6 @@ const GOLD_TAB_STYLE = {
 };
 
 const CATEGORY_STYLE_MAP = new Map([
-  ['RECLAMAÇÕES ML', { ...ORANGE_TAB_STYLE }],
-  ['MEDIAÇÕES ML', { ...ORANGE_TAB_STYLE }],
-  ['RECLAMAÇÕES SHOPEE', { ...ORANGE_TAB_STYLE }],
-  ['FRETE E ENTREGA SHOPEE', { ...ORANGE_TAB_STYLE }],
-  ['MEDIAÇÕES SHOPEE', { ...ORANGE_TAB_STYLE }],
-  ['REGRAS & DICAS ML', { ...GOLD_TAB_STYLE }],
-  ['REGRAS & DICAS SHOPEE', { ...GOLD_TAB_STYLE }],
   ['PRODUTOS E MEDIDAS', {
     bg: '#f8fafc',
     color: '#0f172a',
@@ -180,7 +173,15 @@ const RESERVED_CATEGORY_VALUES = new Set(
 );
 
 function getCategoryStyle(name) {
-  return CATEGORY_STYLE_MAP.get(name) || null;
+  if (!name) return null;
+  const exact = CATEGORY_STYLE_MAP.get(name);
+  if (exact) return exact;
+
+  const upper = name.toUpperCase();
+  if (upper.includes('SHOPEE')) return SHOPEE_TAB_STYLE;
+  if (upper.includes('ML')) return ML_TAB_STYLE;
+
+  return null;
 }
 
 function applyTabStyle(element, category) {

--- a/styles.css
+++ b/styles.css
@@ -58,28 +58,35 @@ a { color: var(--primary); text-decoration: none; }
 .menu-panel {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 28px 30px;
-  border-radius: 26px;
-  background: linear-gradient(135deg, rgba(255,255,255,0.95), rgba(248,250,252,0.95));
+  gap: 16px;
+  padding: 20px 22px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.96));
+  box-shadow: 0 18px 44px -30px rgba(15, 23, 42, 0.45);
 }
 
 .menu-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 14px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
   align-items: stretch;
 }
 
 .menu-panel .btn {
-  border-radius: 999px;
-  height: 52px;
-  padding: 0 24px;
-  font-size: 13px;
+  border-radius: 14px;
+  min-height: 44px;
+  padding: 0 18px;
+  font-size: 12px;
   font-weight: 700;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.4px;
   text-transform: uppercase;
   box-shadow: none;
+}
+
+.menu-actions .btn {
+  width: 100%;
+  justify-content: center;
 }
 
 .menu-panel .btn:hover {
@@ -127,19 +134,23 @@ a { color: var(--primary); text-decoration: none; }
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 12px;
-  flex: 1 1 280px;
-  padding: 0 22px;
-  border-radius: 999px;
+  gap: 10px;
+  flex: 1 1 100%;
+  padding: 0 16px;
+  border-radius: 14px;
   background: #f8fafc;
   border: 1px solid #e2e8f0;
   color: #475569;
   font-weight: 600;
-  height: 52px;
+  height: 44px;
+}
+
+.menu-actions .menu-search {
+  grid-column: 1 / -1;
 }
 
 .menu-search .material-symbols-rounded {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 .menu-search input {
@@ -147,7 +158,7 @@ a { color: var(--primary); text-decoration: none; }
   background: transparent;
   padding: 0;
   width: 100%;
-  font-size: 15px;
+  font-size: 14px;
   color: var(--txt);
 }
 


### PR DESCRIPTION
## Summary
- streamline the menu panel spacing and button sizing to create a more compact, organized control area
- apply automatic yellow styling to ML categories and orange styling to Shopee categories across tabs and chips

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68fa280bbaac832a9a3a90557f5f0fdb